### PR TITLE
Remove obsolete HMMER -pfamB option.

### DIFF
--- a/bash_scripts/run_pfam_scan.sh
+++ b/bash_scripts/run_pfam_scan.sh
@@ -35,7 +35,7 @@ do
 	mkdir $dirname/pfam
         echo "mkdir $dirname/pfam"
     fi
-    CMDSTR+="'time perl pfam_scan.pl -e_seq 1 -e_dom 1 -pfamB -as -outfile $dirname/pfam/${basename}_pfamscan-$(date +%m-%d-%Y).out -cpu 8 -fasta $FILE -dir $Pfam"
+    CMDSTR+="'time perl pfam_scan.pl -e_seq 1 -e_dom 1 -as -outfile $dirname/pfam/${basename}_pfamscan-$(date +%m-%d-%Y).out -cpu 8 -fasta $FILE -dir $Pfam"
     CMDSTR+="'"$'\n'
 
 done


### PR DESCRIPTION
This would fix issue #8 where if using HMMER 3, pfam_scan.pl would otherwise abort saying:

``
FATAL: As of release 28.0, Pfam no longer produces Pfam-B. The -pfamB and -only_pfamB options are now obsolete.
``