### PR TITLE
Improvements to run_pfam_scan.sh

### DIFF
--- a/bash_scripts/run_pfam_scan.sh
+++ b/bash_scripts/run_pfam_scan.sh
@@ -12,7 +12,8 @@
 IN_DIR="$1" 
 
 # set location of Pfam db
-Pfam=
+# By default using $HMMERDB environment variable (as used by HMMER itself)
+Pfam="$HMMERDB"
 
 # set number of jobs to run in parallel
 NUMCORES=1
@@ -21,6 +22,11 @@ NUMCORES=1
 TSTAMP=$(date +%Y%m%d-%H%M%S)
 CMDFILE=commands.${TSTAMP}.txt
 
+if [[ "$Pfam" == "" ]]; then
+    echo "ERROR: Location of Pfam HMM databases not set."
+    echo "Please set the \$HMMERDB environment variable."
+    exit 1
+fi
 if ! type "pfam_scan.pl" > /dev/null; then
     echo "ERROR: pfam_scan.pl is not installed and on \$PATH."
     echo

--- a/bash_scripts/run_pfam_scan.sh
+++ b/bash_scripts/run_pfam_scan.sh
@@ -21,6 +21,13 @@ NUMCORES=1
 TSTAMP=$(date +%Y%m%d-%H%M%S)
 CMDFILE=commands.${TSTAMP}.txt
 
+if ! type "pfam_scan.pl" > /dev/null; then
+    echo "ERROR: pfam_scan.pl is not installed and on \$PATH."
+    echo
+    echo "Check you can run this command at the terminal: pfam_scan.pl -h"
+    exit 1
+fi
+
 protfiles=$(find $IN_DIR -name '*protein.fa')
 for FILE in $protfiles
 do
@@ -35,7 +42,7 @@ do
 	mkdir $dirname/pfam
         echo "mkdir $dirname/pfam"
     fi
-    CMDSTR+="'time perl pfam_scan.pl -e_seq 1 -e_dom 1 -pfamB -as -outfile $dirname/pfam/${basename}_pfamscan-$(date +%m-%d-%Y).out -cpu 8 -fasta $FILE -dir $Pfam"
+    CMDSTR+="'time pfam_scan.pl -e_seq 1 -e_dom 1 -pfamB -as -outfile $dirname/pfam/${basename}_pfamscan-$(date +%m-%d-%Y).out -cpu 8 -fasta $FILE -dir $Pfam"
     CMDSTR+="'"$'\n'
 
 done


### PR DESCRIPTION
Currently it seems the user is expected to edit ``run_pfam_scan.sh`` to set the directory where the Pfam database can be found, instead default to HMMER's convention of ``$HMMERDB``

Also currently it seems the third-party script ``pfam_scan.pl`` is expected to be in the current directory, instead assume it is installed and on ``$PATH``.

Note installing ``pfam_scan.pl`` version 1.6 via the BioConda package I wrote will do this,

```
$ conda install -c bioconda pfam_scan
```

See https://anaconda.org/bioconda/pfam_scan
